### PR TITLE
fix: contention_list missing 'list' subcommand

### DIFF
--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -443,7 +443,7 @@ const valencePlugin = {
           ),
         }),
         async execute(_id: string, params: { article_id?: string; status?: string }) {
-          const args = ["conflicts"];
+          const args = ["conflicts", "list"];
           // Note: CLI conflicts command doesn't support filtering yet
 
           const result = await valenceExec(cfg, args);


### PR DESCRIPTION
One-liner: was calling `valence conflicts` instead of `valence conflicts list`.